### PR TITLE
fix: show player ships on Your Fleet board

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -110,11 +110,12 @@ function updateBoard(containerId, gridState) {
     } else if (state === 'miss') {
       cell.classList.add('miss');
       cell.textContent = '\u00B7'; // ·
-    } else if (state === 'ship') {
-      cell.classList.add('ship');
     } else if (state === 'sunk') {
       cell.classList.add('sunk');
       cell.textContent = '\u2715';
+    } else if (state) {
+      // Any other truthy value is a ship (server sends ship names like 'carrier')
+      cell.classList.add('ship');
     }
   });
 }


### PR DESCRIPTION
## Summary
- Server sends ship names (e.g. `'carrier'`) in the player's grid, not the literal string `'ship'`
- `updateBoard` now treats any truthy value that isn't `hit`/`miss`/`sunk` as a ship cell
- Player's ships are now visible on the 'Your Fleet' board during gameplay

Closes #6

## Test plan
- [ ] Start a game (AI or multiplayer), place ships, begin playing
- [ ] Verify 'Your Fleet' board shows placed ships with green highlight
- [ ] Verify hit/miss/sunk states still render correctly on both boards

🤖 Generated with [Claude Code](https://claude.com/claude-code)