### PR TITLE
fix: add spacing between multiplayer buttons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -106,6 +106,9 @@ body::after {
 
 .menu-section {
   margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .menu-section h2, .menu-section h3 {


### PR DESCRIPTION
## Summary
- Added `display: flex; flex-direction: column; gap: 12px` to `.menu-section`
- Creates consistent vertical spacing between Create Room, Join Room, and Find Opponent groups

Closes #1

## Test plan
- [ ] Verify multiplayer buttons have visible spacing between groups
- [ ] Verify other menu sections (AI modes, leaderboard) still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)