### PR TITLE
feat: click-to-copy room code

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -548,6 +548,16 @@ body::after {
   color: #00ff80;
   text-shadow: 0 0 8px #00ff80;
   margin: 16px 0;
+  cursor: crosshair;
+  user-select: all;
+}
+
+.copy-confirm {
+  font-size: 11px;
+  letter-spacing: 2px;
+  color: #00ff8088;
+  margin-top: -8px;
+  transition: opacity 0.3s;
 }
 
 .room-container,

--- a/public/index.html
+++ b/public/index.html
@@ -114,7 +114,8 @@
     <section id="screen-room" class="screen" aria-label="Room lobby">
       <h2>Room Created</h2>
       <p>Share this code with your opponent:</p>
-      <p id="room-code-display" class="room-code" aria-live="polite"></p>
+      <p id="room-code-display" class="room-code" aria-live="polite" title="Click to copy"></p>
+      <p id="room-code-copied" class="copy-confirm" hidden>Copied!</p>
       <p class="waiting-text blink">Waiting for opponent to join...</p>
       <button id="btn-cancel-room" class="btn-terminal">Cancel</button>
     </section>

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -672,6 +672,25 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  // --- Copy room code on click ---
+  var roomCodeDisplay = document.getElementById('room-code-display');
+  var roomCodeCopied = document.getElementById('room-code-copied');
+  if (roomCodeDisplay) {
+    roomCodeDisplay.addEventListener('click', function () {
+      var code = roomCodeDisplay.textContent.trim();
+      if (!code) return;
+      navigator.clipboard.writeText(code).then(function () {
+        if (roomCodeCopied) {
+          roomCodeCopied.removeAttribute('hidden');
+          clearTimeout(roomCodeCopied._timer);
+          roomCodeCopied._timer = setTimeout(function () {
+            roomCodeCopied.setAttribute('hidden', '');
+          }, 1500);
+        }
+      });
+    });
+  }
+
   // --- Cancel room ---
   var btnCancelRoom = document.getElementById('btn-cancel-room');
   if (btnCancelRoom) {


### PR DESCRIPTION
## Summary
- Room code display is clickable to copy to clipboard
- Shows brief "Copied!" confirmation that auto-hides after 1.5s
- `user-select: all` for easy manual selection as fallback
- Title tooltip hint: "Click to copy"

Closes #22

## Test plan
- [ ] Create a room, click the room code — copies to clipboard
- [ ] "Copied!" appears briefly then hides
- [ ] Clicking again re-copies and re-shows confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)