### PR TITLE
fix: center room lobby screen, add CSS style guide

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -105,6 +105,43 @@ body::after {
   display: block;
 }
 
+/*
+ * STYLE GUIDE — Shared patterns for visual consistency
+ *
+ * Centered screen:    .screen-centered — flex column, centered, padded
+ * Screen heading:     .screen-heading  — uppercase, spaced, dimmed green
+ * Screen subtitle:    .screen-subtitle — small, dimmed, spaced
+ * Button groups:      .gameover-buttons, .placement-controls — flex row, gap
+ * Max-width screens:  max-width 500-700px, margin: 0 auto, padding: 20px
+ * Colors:             #00ff80 (primary), #00ff8088 (dimmed), #ff4444 (danger)
+ */
+
+.screen-centered {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 500px;
+  margin: 0 auto;
+  padding: 40px 20px;
+  gap: 12px;
+}
+
+.screen-heading {
+  font-size: 14px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #00ff80;
+  text-shadow: 0 0 8px #00ff80;
+  margin-bottom: 4px;
+}
+
+.screen-subtitle {
+  font-size: 12px;
+  letter-spacing: 1px;
+  color: #00ff8066;
+}
+
 /* ===== Menu ===== */
 .menu-container {
   max-width: 500px;

--- a/public/index.html
+++ b/public/index.html
@@ -104,7 +104,7 @@
 
     <!-- Screen: Waiting / Matchmaking -->
     <section id="screen-waiting" class="screen" aria-label="Matchmaking">
-      <div class="waiting-content">
+      <div class="screen-centered">
         <p class="blink">Searching for opponent...</p>
         <button id="btn-cancel-wait" class="btn-terminal">Cancel</button>
       </div>
@@ -112,12 +112,14 @@
 
     <!-- Screen: Room Lobby -->
     <section id="screen-room" class="screen" aria-label="Room lobby">
-      <h2>Room Created</h2>
-      <p>Share this code with your opponent:</p>
-      <p id="room-code-display" class="room-code" aria-live="polite" title="Click to copy"></p>
-      <p id="room-code-copied" class="copy-confirm" hidden>Copied!</p>
-      <p class="waiting-text blink">Waiting for opponent to join...</p>
-      <button id="btn-cancel-room" class="btn-terminal">Cancel</button>
+      <div class="screen-centered">
+        <h2 class="screen-heading">Room Created</h2>
+        <p class="screen-subtitle">Share this code with your opponent:</p>
+        <p id="room-code-display" class="room-code" aria-live="polite" title="Click to copy"></p>
+        <p id="room-code-copied" class="copy-confirm" hidden>Copied!</p>
+        <p class="screen-subtitle blink">Waiting for opponent to join...</p>
+        <button id="btn-cancel-room" class="btn-terminal">Cancel</button>
+      </div>
     </section>
 
     <!-- Screen: Ship Placement -->


### PR DESCRIPTION
## Summary
- Room lobby screen fully centered — heading, room code, waiting text, cancel button
- Matchmaking/waiting screen also centered
- Added reusable `.screen-centered`, `.screen-heading`, `.screen-subtitle` CSS patterns
- Inline style guide comment documenting shared patterns and conventions

Closes #47

## Test plan
- [ ] Create a room — all content centered, heading styled consistently
- [ ] Find Opponent — waiting screen centered
- [ ] Room code still clickable to copy
- [ ] Cancel buttons work from both screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)