### PR TITLE
feat: copy icon next to room code

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -589,6 +589,29 @@ body::after {
   user-select: all;
 }
 
+.room-code-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  cursor: crosshair;
+  transition: opacity 0.2s;
+}
+
+.room-code-wrapper:hover {
+  opacity: 0.8;
+}
+
+.copy-icon {
+  width: 20px;
+  height: 20px;
+  color: #00ff8055;
+  transition: color 0.2s;
+}
+
+.room-code-wrapper:hover .copy-icon {
+  color: #00ff80;
+}
+
 .copy-confirm {
   font-size: 11px;
   letter-spacing: 2px;

--- a/public/index.html
+++ b/public/index.html
@@ -115,7 +115,13 @@
       <div class="screen-centered">
         <h2 class="screen-heading">Room Created</h2>
         <p class="screen-subtitle">Share this code with your opponent:</p>
-        <p id="room-code-display" class="room-code" aria-live="polite" title="Click to copy"></p>
+        <p class="room-code-wrapper" title="Click to copy">
+          <span id="room-code-display" class="room-code" aria-live="polite"></span>
+          <svg class="copy-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="9" y="9" width="13" height="13" rx="2"/>
+            <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/>
+          </svg>
+        </p>
         <p id="room-code-copied" class="copy-confirm" hidden>Copied!</p>
         <p class="screen-subtitle blink">Waiting for opponent to join...</p>
         <button id="btn-cancel-room" class="btn-terminal">Cancel</button>

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -674,9 +674,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // --- Copy room code on click ---
   var roomCodeDisplay = document.getElementById('room-code-display');
+  var roomCodeWrapper = roomCodeDisplay && roomCodeDisplay.closest('.room-code-wrapper');
   var roomCodeCopied = document.getElementById('room-code-copied');
-  if (roomCodeDisplay) {
-    roomCodeDisplay.addEventListener('click', function () {
+  if (roomCodeWrapper) {
+    roomCodeWrapper.addEventListener('click', function () {
       var code = roomCodeDisplay.textContent.trim();
       if (!code) return;
       navigator.clipboard.writeText(code).then(function () {


### PR DESCRIPTION
## Summary
- Added SVG copy icon (two overlapping rectangles) next to the room code
- Icon dims when idle (#00ff8055), brightens on hover (#00ff80)
- Click target wraps both code and icon
- Whole row has hover feedback (slight opacity change)

## Test plan
- [ ] Create room — copy icon visible next to code
- [ ] Hover highlights icon
- [ ] Click anywhere on code/icon copies and shows "Copied!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)