### PR TITLE
feat: keyboard shortcut hints on placement buttons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -135,9 +135,9 @@
         <div class="placement-board-column">
           <div id="board-placement" class="board board-large" role="grid" aria-label="Ship placement board"></div>
           <div class="placement-controls">
-            <button id="btn-rotate" class="btn-terminal">Rotate Ship [R]</button>
-            <button id="btn-randomize" class="btn-terminal">Randomize</button>
-            <button id="btn-ready" class="btn-terminal">Ready</button>
+            <button id="btn-rotate" class="btn-terminal">Rotate [R]</button>
+            <button id="btn-randomize" class="btn-terminal">Randomize [S]</button>
+            <button id="btn-ready" class="btn-terminal">Ready [Enter]</button>
           </div>
         </div>
         <div class="ship-list" id="ship-list" aria-label="Ships to place">

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -805,7 +805,7 @@ document.addEventListener('DOMContentLoaded', function () {
     placementState.orientation =
       placementState.orientation === 'horizontal' ? 'vertical' : 'horizontal';
     if (btnRotate) {
-      btnRotate.textContent = 'Rotate Ship [R]';
+      btnRotate.textContent = 'Rotate [R]';
     }
     // Refresh hover preview so the rotated orientation is visible immediately
     if (placementState.lastHoverRow >= 0 && placementState.lastHoverCol >= 0) {
@@ -817,15 +817,6 @@ document.addEventListener('DOMContentLoaded', function () {
     btnRotate.addEventListener('click', _rotateShip);
   }
 
-  // R key shortcut for rotate
-  document.addEventListener('keydown', function (e) {
-    var activeScreen = document.querySelector('#screen-placement.active');
-    if (!activeScreen) return;
-    if (e.key === 'r' || e.key === 'R') {
-      _rotateShip();
-    }
-  });
-
   // Randomize button
   var btnRandomize = document.getElementById('btn-randomize');
   if (btnRandomize) {
@@ -836,14 +827,29 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Ready button
   var btnReady = document.getElementById('btn-ready');
-  if (btnReady) {
-    btnReady.addEventListener('click', function () {
-      if (placementState.placedShips.length < FLEET.length) return;
-      if (socket) {
-        socket.emit('place-ships', { ships: placementState.placedShips });
-      }
-    });
+  function _submitReady() {
+    if (!btnReady || btnReady.disabled) return;
+    if (placementState.placedShips.length < FLEET.length) return;
+    if (socket) {
+      socket.emit('place-ships', { ships: placementState.placedShips });
+    }
   }
+  if (btnReady) {
+    btnReady.addEventListener('click', _submitReady);
+  }
+
+  // Keyboard shortcuts for placement screen
+  document.addEventListener('keydown', function (e) {
+    var activeScreen = document.querySelector('#screen-placement.active');
+    if (!activeScreen) return;
+    if (e.key === 'r' || e.key === 'R') {
+      _rotateShip();
+    } else if (e.key === 's' || e.key === 'S') {
+      _randomizePlacement();
+    } else if (e.key === 'Enter') {
+      _submitReady();
+    }
+  });
 
   // Initialize placement board when placement screen becomes active
   // game.js calls showScreen('screen-placement'), which we intercept by


### PR DESCRIPTION
## Summary
- Rotate [R], Randomize [S], Ready [Enter] — labels and working shortcuts
- Consolidated into single keydown listener for placement screen
- Ready shortcut respects disabled state (not all ships placed)

Closes #23

## Test plan
- [ ] R key rotates ship orientation
- [ ] S key randomizes all ship placements
- [ ] Enter key submits placement when all ships placed
- [ ] Enter does nothing when Ready is disabled
- [ ] Button labels show shortcut hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)