### PR TITLE
feat: Play Again replays same AI difficulty

### DIFF
--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -5,6 +5,9 @@
 
 'use strict';
 
+// Track last game mode for Play Again
+var _lastGameMode = null; // { type: 'ai', difficulty: 'easy' } or { type: 'multiplayer' }
+
 // ---------------------------------------------------------------------------
 // Screen management
 // ---------------------------------------------------------------------------
@@ -633,6 +636,7 @@ document.addEventListener('DOMContentLoaded', function () {
       var mode = btn.getAttribute('data-mode');
       // Extract difficulty: ai_easy → easy, ai_medium → medium, ai_hard → hard
       var difficulty = mode.replace('ai_', '');
+      _lastGameMode = { type: 'ai', difficulty: difficulty };
       if (socket) socket.emit('create-ai-game', { difficulty: difficulty });
     });
   });
@@ -785,7 +789,11 @@ document.addEventListener('DOMContentLoaded', function () {
   var btnPlayAgain = document.getElementById('btn-play-again');
   if (btnPlayAgain) {
     btnPlayAgain.addEventListener('click', function () {
-      showScreen('screen-menu');
+      if (_lastGameMode && _lastGameMode.type === 'ai' && socket) {
+        socket.emit('create-ai-game', { difficulty: _lastGameMode.difficulty });
+      } else {
+        showScreen('screen-menu');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Play Again on game over screen immediately starts a new AI game at the same difficulty
- Tracks `_lastGameMode` when starting games
- Falls back to main menu for multiplayer games (can't auto-rematch)
- Main Menu button unchanged — always returns to menu

Closes #24

## Test plan
- [ ] Play AI Easy, win/lose, click Play Again — starts new Easy game
- [ ] Play AI Hard, click Play Again — starts new Hard game
- [ ] Main Menu button still returns to menu
- [ ] Multiplayer game → Play Again returns to menu (no auto-rematch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)