### PR TITLE
feat: turn change beep and status bar pulse

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -375,6 +375,29 @@ body::after {
 }
 
 /* ===== Game Container ===== */
+#status-bar {
+  text-align: center;
+  padding: 8px;
+  margin-bottom: 12px;
+  border: 1px solid #00ff8022;
+  transition: border-color 0.3s;
+}
+
+#status-bar.pulse {
+  animation: statusPulse 0.6s ease-out;
+}
+
+@keyframes statusPulse {
+  0% {
+    border-color: #00ff80;
+    box-shadow: 0 0 12px #00ff8044;
+  }
+  100% {
+    border-color: #00ff8022;
+    box-shadow: none;
+  }
+}
+
 .game-container {
   max-width: 500px;
   margin: 0 auto;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -167,6 +167,23 @@ function showNotification(message) {
  * updateTurnIndicator(isMyTurn)
  * Updates #status-turn text and styling.
  */
+function _playTurnBeep() {
+  if (SoundManager.muted) return;
+  try {
+    var ctx = new (window.AudioContext || window.webkitAudioContext)();
+    var osc = ctx.createOscillator();
+    var gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = 880;
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.15);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.15);
+  } catch (e) { /* ignore audio errors */ }
+}
+
 function updateTurnIndicator(isMyTurn) {
   var el = document.getElementById('status-turn');
   if (!el) return;
@@ -174,9 +191,18 @@ function updateTurnIndicator(isMyTurn) {
   if (isMyTurn) {
     el.textContent = 'YOUR TURN';
     el.style.color = '#00ff80';
+    _playTurnBeep();
   } else {
     el.textContent = "OPPONENT'S TURN";
     el.style.color = '#ff6b6b';
+  }
+
+  // Pulse the status bar
+  var bar = document.getElementById('status-bar');
+  if (bar) {
+    bar.classList.remove('pulse');
+    void bar.offsetWidth;
+    bar.classList.add('pulse');
   }
 }
 


### PR DESCRIPTION
## Summary
- 880Hz sine wave beep (150ms) via Web Audio API when it becomes your turn
- Status bar pulses green border + glow on every turn change
- Beep respects SoundManager mute setting
- No new audio files — sound generated programmatically

Closes #27

## Test plan
- [ ] Play AI game — status bar pulses on each turn change
- [ ] With sound ON, hear beep when it becomes your turn
- [ ] With sound OFF, no beep but pulse still visible
- [ ] Pulse doesn't stack or break on rapid turn changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)