### PR TITLE
feat: water ripple effect on board clicks

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -308,6 +308,48 @@ body::after {
   background: #00ff8011;
 }
 
+.cell.ripple {
+  position: relative;
+  overflow: visible;
+}
+
+.cell.ripple::before,
+.cell.ripple::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #00ff8088;
+  transform: translate(-50%, -50%) scale(0);
+  animation: waterRipple 0.8s ease-out forwards;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.cell.ripple::after {
+  animation-delay: 0.15s;
+}
+
+@keyframes waterRipple {
+  0% {
+    transform: translate(-50%, -50%) scale(0);
+    opacity: 0.8;
+    border-width: 2px;
+  }
+  50% {
+    opacity: 0.4;
+    border-width: 1px;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(8);
+    opacity: 0;
+    border-width: 0.5px;
+  }
+}
+
 .cell.hit {
   background: #ff003322;
   border-color: #ff003366;

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -129,6 +129,41 @@ function updateBoard(containerId, gridState) {
  * Emits a 'fire' event if it is this player's turn.
  * Temporarily disables the enemy board to prevent double-fire.
  */
+function _spawnRipple(row, col) {
+  var board = document.getElementById('board-enemy');
+  if (!board) return;
+  var cell = board.querySelector('.cell[data-row="' + row + '"][data-col="' + col + '"]');
+  if (!cell) return;
+
+  cell.classList.remove('ripple');
+  void cell.offsetWidth;
+  cell.classList.add('ripple');
+
+  // Spawn extra ripple rings on neighboring cells for spread effect
+  var neighbors = [
+    [row - 1, col], [row + 1, col], [row, col - 1], [row, col + 1]
+  ];
+  neighbors.forEach(function (pos, i) {
+    var n = board.querySelector('.cell[data-row="' + pos[0] + '"][data-col="' + pos[1] + '"]');
+    if (n) {
+      setTimeout(function () {
+        n.classList.remove('ripple');
+        void n.offsetWidth;
+        n.classList.add('ripple');
+      }, 100 + i * 60);
+    }
+  });
+
+  // Clean up classes after animation
+  setTimeout(function () {
+    cell.classList.remove('ripple');
+    neighbors.forEach(function (pos) {
+      var n = board.querySelector('.cell[data-row="' + pos[0] + '"][data-col="' + pos[1] + '"]');
+      if (n) n.classList.remove('ripple');
+    });
+  }, 1200);
+}
+
 function fireAt(row, col) {
   if (!myTurn) return;
   if (!socket) return;
@@ -137,6 +172,7 @@ function fireAt(row, col) {
   myTurn = false;
   updateTurnIndicator(false);
 
+  _spawnRipple(row, col);
   socket.emit('fire', { row: row, col: col });
   SoundManager.play('fire');
 }


### PR DESCRIPTION
## Summary
- Concentric ring ripple animation on the clicked cell when firing a shot
- Two rings per cell (::before + ::after) with staggered 150ms delay
- Ripple spreads to 4 neighboring cells with cascading delays (100-340ms)
- Green-themed rings that expand and fade, matching the terminal aesthetic
- Pure CSS animation — no canvas or libraries
- Auto-cleanup after 1.2s

Closes #45

## Test plan
- [ ] Start AI game, fire a shot — ripple rings expand from clicked cell
- [ ] Neighboring cells also ripple with slight delay
- [ ] Ripple doesn't interfere with hit/miss result appearing
- [ ] Works on edge/corner cells (fewer neighbors)
- [ ] No stacking issues on rapid clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)