### PR TITLE
feat: screen shake on hit and sunk

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -125,6 +125,35 @@ function updateBoard(containerId, gridState) {
 // ---------------------------------------------------------------------------
 
 /**
+ * _shakeScreen(intensity)
+ * Shakes the game screen with random jitter.
+ * intensity: 'light' (hit) or 'heavy' (sunk)
+ */
+function _shakeScreen(intensity) {
+  var el = document.getElementById('screen-game');
+  if (!el) return;
+
+  var frames = intensity === 'heavy' ? 12 : 6;
+  var maxOffset = intensity === 'heavy' ? 8 : 3;
+  var i = 0;
+
+  function jitter() {
+    if (i >= frames) {
+      el.style.transform = '';
+      return;
+    }
+    var decay = 1 - (i / frames);
+    var x = (Math.random() * 2 - 1) * maxOffset * decay;
+    var y = (Math.random() * 2 - 1) * maxOffset * decay;
+    el.style.transform = 'translate(' + x + 'px, ' + y + 'px)';
+    i++;
+    requestAnimationFrame(jitter);
+  }
+
+  requestAnimationFrame(jitter);
+}
+
+/**
  * fireAt(row, col)
  * Emits a 'fire' event if it is this player's turn.
  * Temporarily disables the enemy board to prevent double-fire.
@@ -395,6 +424,7 @@ function connectSocket() {
       updateSingleCell('board-enemy', data.row, data.col, data.result);
       if (data.result === 'hit' || data.result === 'sunk') {
         SoundManager.play(data.sunk ? 'sunk' : 'hit');
+        _shakeScreen(data.sunk ? 'heavy' : 'light');
       } else {
         SoundManager.play('miss');
       }
@@ -403,6 +433,7 @@ function connectSocket() {
       updateSingleCell('board-player', data.row, data.col, data.result);
       if (data.result === 'hit' || data.result === 'sunk') {
         SoundManager.play(data.sunk ? 'sunk' : 'hit');
+        _shakeScreen(data.sunk ? 'heavy' : 'light');
       } else {
         SoundManager.play('miss');
       }


### PR DESCRIPTION
## Summary
- **Hit**: light shake — 6 frames, 3px max jitter, decaying
- **Sunk**: heavy shake — 12 frames, 8px max jitter, decaying
- JS-driven `requestAnimationFrame` loop with random x/y offsets
- Amplitude decays linearly per frame for natural settle
- Triggers on both your shots and opponent's shots hitting your ships

Closes #60

## Test plan
- [ ] Hit an enemy ship — brief light shake
- [ ] Sink an enemy ship — stronger, longer shake
- [ ] Get hit by opponent — light shake
- [ ] Opponent sinks your ship — heavy shake
- [ ] Miss — no shake
- [ ] Shake resets cleanly (no residual offset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)