### PR TITLE
feat: rework game UI — side-by-side desktop layout

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -496,6 +496,46 @@ body::after {
   }
 }
 
+.game-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 16px 20px;
+}
+
+.game-layout {
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.board-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.board-column-primary {
+  flex: 0 0 auto;
+}
+
+.board-column-secondary {
+  flex: 0 0 auto;
+}
+
+.board-label {
+  font-size: 11px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: #00ff8066;
+  margin-bottom: 8px;
+  text-align: center;
+}
+
+.board-column-primary .board-label {
+  color: #00ff80aa;
+  text-shadow: 0 0 4px #00ff8022;
+}
+
 .game-container {
   max-width: 500px;
   margin: 0 auto;
@@ -876,11 +916,10 @@ body::after {
 /* ===== Ship Status ===== */
 .ship-status {
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
+  gap: 4px;
   font-size: 11px;
-  margin-top: 8px;
+  margin-top: 12px;
   color: #00ff8088;
 }
 
@@ -911,6 +950,12 @@ body::after {
   .room-code {
     font-size: 28px;
     letter-spacing: 6px;
+  }
+
+  .game-layout {
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
   }
 
   .board-large {

--- a/public/index.html
+++ b/public/index.html
@@ -148,22 +148,24 @@
 
     <!-- Screen: Game -->
     <section id="screen-game" class="screen" aria-label="Game in progress">
-      <div id="status-bar" class="status-bar" aria-live="polite">
-        <span id="status-message">Your turn</span>
-        <span id="status-turn"></span>
-      </div>
-      <div class="game-layout">
-        <div class="board-container">
-          <h2>Enemy Waters</h2>
-          <div id="board-enemy" class="board board-large" role="grid" aria-label="Enemy board — click to attack"></div>
+      <div class="game-wrapper">
+        <div id="status-bar" class="status-bar" aria-live="polite">
+          <span id="status-message">Your turn</span>
+          <span id="status-turn"></span>
         </div>
-        <div class="board-container">
-          <h2>Your Fleet</h2>
-          <div id="board-player" class="board board-small" role="grid" aria-label="Your board"></div>
+        <div class="game-layout">
+          <div class="board-column board-column-primary">
+            <h2 class="board-label">Enemy Waters</h2>
+            <div id="board-enemy" class="board board-large" role="grid" aria-label="Enemy board — click to attack"></div>
+          </div>
+          <div class="board-column board-column-secondary">
+            <h2 class="board-label">Your Fleet</h2>
+            <div id="board-player" class="board board-small" role="grid" aria-label="Your board"></div>
+            <div id="ship-status" class="ship-status" aria-label="Ship status">
+              <!-- Ship health rendered by JS -->
+            </div>
+          </div>
         </div>
-      </div>
-      <div id="ship-status" class="ship-status" aria-label="Ship status">
-        <!-- Ship health rendered by JS -->
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- Side-by-side layout: enemy board (large, left) + player board (small, right) with ship status beneath
- Board labels: subtle uppercase, enemy label brighter than player
- Status bar centered in 900px game wrapper
- Ship status vertical list in right column
- Mobile responsive: stacks vertically at 600px breakpoint

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)