### PR TITLE
fix: player board resizes after first hit

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -345,7 +345,8 @@ body::after {
 }
 
 .board-small {
-  max-width: 280px;
+  width: 280px;
+  max-width: 100%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
Set explicit `width: 280px` on `.board-small` instead of only `max-width`. Board was starting tiny when cells were empty and jumping larger on first game-state update.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)