### PR TITLE
feat: targeting highlight on enemy board hover

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -369,6 +369,13 @@ body::after {
   background: #00ff8011;
 }
 
+/* Targeting highlight on enemy board */
+#board-enemy .cell:not(.hit):not(.miss):not(.sunk):hover {
+  border-color: #00ff80;
+  background: #00ff8022;
+  box-shadow: 0 0 8px #00ff8033, inset 0 0 6px #00ff8022;
+}
+
 .cell.wave {
   animation: wave3d var(--wave-duration, 0.6s) ease-out forwards;
   animation-delay: var(--wave-delay, 0s);


### PR DESCRIPTION
## Summary
- Untargeted enemy board cells get a brighter glow on hover: green border, background tint, outer + inner box-shadow
- Hit/miss/sunk cells excluded via :not() selectors
- Pure CSS, no JS changes

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)