### PR TITLE
feat: motion toggle to disable all animations

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -943,6 +943,19 @@ body::after {
   100% { opacity: 0; }
 }
 
+/* ===== Reduce Motion ===== */
+.reduce-motion *,
+.reduce-motion *::before,
+.reduce-motion *::after {
+  animation-duration: 0.001s !important;
+  animation-delay: 0s !important;
+  transition-duration: 0.001s !important;
+}
+
+.reduce-motion #gameover-title.defeat {
+  filter: none;
+}
+
 /* ===== Responsive ===== */
 @media (max-width: 600px) {
   #main-title {

--- a/public/index.html
+++ b/public/index.html
@@ -221,6 +221,11 @@
       </div>
 
       <div class="settings-group">
+        <label class="settings-label">Motion</label>
+        <button id="btn-motion" class="btn-terminal settings-toggle" aria-label="Toggle motion effects">ON</button>
+      </div>
+
+      <div class="settings-group">
         <label class="settings-label">Theme</label>
         <span class="settings-hint">Coming soon</span>
       </div>

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -130,6 +130,7 @@ function updateBoard(containerId, gridState) {
  * intensity: 'light' (hit) or 'heavy' (sunk)
  */
 function _shakeScreen(intensity) {
+  if (typeof MotionSettings !== 'undefined' && !MotionSettings.enabled) return;
   var el = document.getElementById('screen-game');
   if (!el) return;
 
@@ -159,6 +160,7 @@ function _shakeScreen(intensity) {
  * Temporarily disables the enemy board to prevent double-fire.
  */
 function _spawnRipple(row, col) {
+  if (typeof MotionSettings !== 'undefined' && !MotionSettings.enabled) return;
   var board = document.getElementById('board-enemy');
   if (!board) return;
 
@@ -497,7 +499,7 @@ function connectSocket() {
       void title.offsetWidth;
       title.classList.add(iWon ? 'victory' : 'defeat');
 
-      if (!iWon) {
+      if (!iWon && typeof MotionSettings !== 'undefined' && MotionSettings.enabled) {
         var anims = document.querySelectorAll('#defeat-wave animate');
         anims.forEach(function (a) { a.beginElement(); });
       }

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -5,6 +5,32 @@
 
 'use strict';
 
+// Global motion settings — checked by all animation/effect functions
+var MotionSettings = {
+  enabled: true,
+  init: function () {
+    // Respect OS-level preference
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      this.enabled = false;
+    }
+    // Override with saved user preference
+    var saved = localStorage.getItem('cyber-ship-battle-motion');
+    if (saved === 'off') this.enabled = false;
+    if (saved === 'on') this.enabled = true;
+    this._applyClass();
+  },
+  toggle: function () {
+    this.enabled = !this.enabled;
+    localStorage.setItem('cyber-ship-battle-motion', this.enabled ? 'on' : 'off');
+    this._applyClass();
+    return this.enabled;
+  },
+  _applyClass: function () {
+    document.documentElement.classList.toggle('reduce-motion', !this.enabled);
+  }
+};
+MotionSettings.init();
+
 // Track last game mode for Play Again
 var _lastGameMode = null; // { type: 'ai', difficulty: 'easy' } or { type: 'multiplayer' }
 
@@ -55,6 +81,7 @@ function _loadConfetti(callback) {
 }
 
 function _fireVictoryConfetti() {
+  if (!MotionSettings.enabled) return;
   _loadConfetti(function () {
     if (typeof confetti !== 'function') return;
 
@@ -102,7 +129,7 @@ function showGameOver(data) {
     title.classList.add(data.won ? 'victory' : 'defeat');
 
     // Restart SVG filter animations for defeat wave effect
-    if (!data.won) {
+    if (!data.won && MotionSettings.enabled) {
       var anims = document.querySelectorAll('#defeat-wave animate');
       anims.forEach(function (a) { a.beginElement(); });
     }
@@ -786,6 +813,16 @@ document.addEventListener('DOMContentLoaded', function () {
       var muted = SoundManager.toggle();
       btnSound.textContent = muted ? 'OFF' : 'ON';
       localStorage.setItem('battleship-sound', muted ? 'off' : 'on');
+    });
+  }
+
+  // --- Motion toggle (inside settings) ---
+  var btnMotion = document.getElementById('btn-motion');
+  if (btnMotion) {
+    btnMotion.textContent = MotionSettings.enabled ? 'ON' : 'OFF';
+    btnMotion.addEventListener('click', function () {
+      var enabled = MotionSettings.toggle();
+      btnMotion.textContent = enabled ? 'ON' : 'OFF';
     });
   }
 


### PR DESCRIPTION
## Summary
- Motion ON/OFF in settings, persisted in localStorage
- Respects OS \`prefers-reduced-motion\` on first load
- JS guards on: confetti, screen shake, water ripple, defeat wave SVG
- CSS \`.reduce-motion\` class zeroes all animation/transition durations
- Defeat SVG filter removed when motion disabled

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)