### PR TITLE
feat: pixel-block ship visuals in placement list

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -586,7 +586,11 @@ body::after {
 }
 
 .ship-item {
-  padding: 6px 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
   margin-bottom: 4px;
   border: 1px solid #00ff8033;
   cursor: crosshair;
@@ -604,8 +608,33 @@ body::after {
   text-shadow: 0 0 8px #00ff80;
 }
 
+.ship-item.selected .ship-block {
+  background: #00ff80;
+  box-shadow: 0 0 4px #00ff80;
+}
+
 .ship-item.placed {
   opacity: 0.5;
+}
+
+.ship-item.placed .ship-block {
+  background: #00ff8044;
+  border-color: #00ff8022;
+  box-shadow: none;
+}
+
+.ship-blocks {
+  display: flex;
+  gap: 2px;
+}
+
+.ship-block {
+  width: 14px;
+  height: 14px;
+  background: #00ff8066;
+  border: 1px solid #00ff8044;
+  border-radius: 1px;
+  transition: all 0.15s;
 }
 
 /* ===== Game Over ===== */

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -257,12 +257,16 @@ function _renderShipList() {
     nameSpan.className = 'ship-name';
     nameSpan.textContent = ship.name;
 
-    var sizeSpan = document.createElement('span');
-    sizeSpan.className = 'ship-size';
-    sizeSpan.textContent = '[' + ship.size + ']';
+    var blocksDiv = document.createElement('div');
+    blocksDiv.className = 'ship-blocks';
+    for (var b = 0; b < ship.size; b++) {
+      var block = document.createElement('span');
+      block.className = 'ship-block';
+      blocksDiv.appendChild(block);
+    }
 
     item.appendChild(nameSpan);
-    item.appendChild(sizeSpan);
+    item.appendChild(blocksDiv);
 
     item.addEventListener('click', function () {
       var shipNameLower = ship.name.toLowerCase();


### PR DESCRIPTION
## Summary
- Ship list items now show a row of 14px square blocks matching ship size
- Blocks glow bright green when ship is selected
- Blocks dim when ship is placed
- Ship name left, blocks right, flexbox layout
- Replaces the old [size] text notation

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)