### PR TITLE
feat: two-click ship pickup with highlight confirmation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -431,6 +431,12 @@ body::after {
   border-color: #00ff8044;
 }
 
+.cell.ship-focused {
+  background: #ffaa0022;
+  border-color: #ffaa00aa;
+  animation: focusPulse 1s ease-in-out infinite alternate;
+}
+
 .cell.preview-valid {
   background: #00ff8025;
   border-color: #00ff8088;
@@ -647,6 +653,17 @@ body::after {
 
 .ship-item.placed {
   opacity: 0.5;
+}
+
+.ship-item.placed.focused {
+  opacity: 1;
+  border-color: #ffaa00;
+  animation: focusPulse 1s ease-in-out infinite alternate;
+}
+
+.ship-item.placed.focused .ship-block {
+  background: #ffaa0088;
+  border-color: #ffaa0066;
 }
 
 .ship-item.placed .ship-block {
@@ -1172,6 +1189,11 @@ body::after {
 @keyframes blink {
   from { opacity: 1; }
   to   { opacity: 0.3; }
+}
+
+@keyframes focusPulse {
+  from { opacity: 1; }
+  to   { opacity: 0.6; }
 }
 
 @keyframes fadeOut {

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -178,7 +178,9 @@ var placementState = {
   // 10x10 grid tracking which cells are occupied
   occupiedGrid: null,
   lastHoverRow: -1,
-  lastHoverCol: -1
+  lastHoverCol: -1,
+  // Index into placedShips of the focused (first-click highlighted) ship, or -1
+  focusedPlacedShip: -1
 };
 
 function _initOccupiedGrid() {
@@ -275,17 +277,28 @@ function _renderShipList() {
       });
 
       if (placedIdx !== -1) {
-        // Clicking a placed ship — remove it from board and re-select
-        _pickUpPlacedShip(placedIdx);
+        if (placementState.focusedPlacedShip === placedIdx) {
+          // Second click on focused ship — pick it up
+          placementState.focusedPlacedShip = -1;
+          _pickUpPlacedShip(placedIdx);
+        } else {
+          // First click on placed ship — focus/highlight it
+          placementState.focusedPlacedShip = placedIdx;
+          _updateShipListUI();
+          _redrawPlacedShips();
+        }
       } else if (placementState.selectedShip === idx) {
         // Clicking the currently selected ship — deselect (drop it)
         placementState.selectedShip = -1;
+        placementState.focusedPlacedShip = -1;
         _updateShipListUI();
         _clearPreview();
       } else {
         // Clicking an unplaced, unselected ship — select it
         placementState.selectedShip = idx;
+        placementState.focusedPlacedShip = -1;
         _updateShipListUI();
+        _redrawPlacedShips();
       }
     });
 
@@ -299,13 +312,21 @@ function _updateShipListUI() {
   var items = document.querySelectorAll('.ship-item');
   items.forEach(function (item) {
     var idx = parseInt(item.getAttribute('data-ship-index'), 10);
-    item.classList.remove('selected', 'placed');
+    item.classList.remove('selected', 'placed', 'focused');
 
-    var isPlaced = placementState.placedShips.some(function (p) {
-      return p.name === FLEET[idx].name.toLowerCase();
-    });
-    if (isPlaced) {
+    var placedIdx = -1;
+    for (var p = 0; p < placementState.placedShips.length; p++) {
+      if (placementState.placedShips[p].name === FLEET[idx].name.toLowerCase()) {
+        placedIdx = p;
+        break;
+      }
+    }
+
+    if (placedIdx !== -1) {
       item.classList.add('placed');
+      if (placementState.focusedPlacedShip === placedIdx) {
+        item.classList.add('focused');
+      }
     } else if (idx === placementState.selectedShip) {
       item.classList.add('selected');
     }
@@ -404,7 +425,22 @@ function _handlePlacementClick(row, col) {
 
   if (!holdingShip) {
     var placedIdx = _findPlacedShipAt(row, col);
-    if (placedIdx !== -1) _pickUpPlacedShip(placedIdx);
+    if (placedIdx !== -1) {
+      if (placementState.focusedPlacedShip === placedIdx) {
+        // Second click — pick it up
+        placementState.focusedPlacedShip = -1;
+        _pickUpPlacedShip(placedIdx);
+      } else {
+        // First click — focus/highlight
+        placementState.focusedPlacedShip = placedIdx;
+        _updateShipListUI();
+        _redrawPlacedShips();
+      }
+    } else {
+      // Clicked empty cell with no ship held — clear focus
+      placementState.focusedPlacedShip = -1;
+      _redrawPlacedShips();
+    }
     return;
   }
 
@@ -415,6 +451,7 @@ function _handlePlacementClick(row, col) {
 
   // Mark on grid
   _markCells(col, row, ship.size, placementState.orientation, placementState.occupiedGrid);
+  placementState.focusedPlacedShip = -1;
 
   // Record placement
   placementState.placedShips.push({
@@ -525,17 +562,21 @@ function _redrawPlacedShips() {
   // Clear ship class from all cells first
   var allCells = board.querySelectorAll('.cell');
   allCells.forEach(function (cell) {
-    cell.classList.remove('ship');
+    cell.classList.remove('ship', 'ship-focused');
   });
 
   // Re-apply ship class for each placed ship
-  placementState.placedShips.forEach(function (placed) {
+  placementState.placedShips.forEach(function (placed, i) {
     var cells = _getShipCells(placed.col, placed.row, placed.size, placed.orientation);
+    var isFocused = (placementState.focusedPlacedShip === i);
     cells.forEach(function (pos) {
       var cell = board.querySelector(
         '.cell[data-row="' + pos.row + '"][data-col="' + pos.col + '"]'
       );
-      if (cell) cell.classList.add('ship');
+      if (cell) {
+        cell.classList.add('ship');
+        if (isFocused) cell.classList.add('ship-focused');
+      }
     });
   });
 }
@@ -544,6 +585,7 @@ function _randomizePlacement() {
   // Reset
   placementState.placedShips = [];
   placementState.occupiedGrid = _initOccupiedGrid();
+  placementState.focusedPlacedShip = -1;
 
   for (var i = 0; i < FLEET.length; i++) {
     var ship = FLEET[i];


### PR DESCRIPTION
## Summary
- First click on a placed ship: highlights with amber pulsing border (board + list)
- Second click: picks it up for repositioning (existing behavior)
- Clicking elsewhere/different ship/placing/randomizing clears the focus
- New state: \`focusedPlacedShip\` tracks the highlighted ship index
- CSS: \`.ship-focused\` (board) and \`.focused\` (list) with amber colors + pulse animation

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)