### PR TITLE
feat: Escape key drops held ship

### DIFF
--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -946,6 +946,10 @@ document.addEventListener('DOMContentLoaded', function () {
       _randomizePlacement();
     } else if (e.key === 'z' || e.key === 'Z') {
       _undoLastPlacement();
+    } else if (e.key === 'Escape') {
+      placementState.selectedShip = -1;
+      _updateShipListUI();
+      _clearPreview();
     } else if (e.key === 'Enter') {
       _submitReady();
     }


### PR DESCRIPTION
## Summary
- Escape key deselects the currently held ship during placement
- Clears hover preview immediately
- Only active on placement screen

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)