### PR TITLE
fix: re-enable player clicks after AI delay

### DIFF
--- a/server/socket/handlers.js
+++ b/server/socket/handlers.js
@@ -282,6 +282,9 @@ function setupSocketHandlers(io) {
             for (const player of room.players) {
               socketToRoom.delete(player.socketId);
             }
+          } else {
+            // AI didn't win — return turn to human
+            io.to(roomId).emit('turn-change', { currentTurn: room.currentTurn });
           }
         }, aiDelay);
       } else if (result.gameOver) {


### PR DESCRIPTION
## Summary
AI turn delay (#110) broke the turn flow — no turn-change was emitted after the delayed AI fire-result, so the player could never click again.

Added turn-change emit inside the setTimeout after the AI fires (when game isn't over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)