### PR TITLE
fix: oscilloscope canvas stuck onscreen

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -346,8 +346,14 @@ function updateTurnIndicator(isMyTurn) {
   var msgEl = document.getElementById('status-message');
   if (!bar) return;
 
-  // Clear any pending transition
+  // Clear any pending transition and orphaned canvases
   if (_turnTransitionTimer) clearTimeout(_turnTransitionTimer);
+  var oldLines = bar.querySelectorAll('.status-line');
+  oldLines.forEach(function (ol) {
+    if (ol._animId) cancelAnimationFrame(ol._animId);
+    ol.parentNode.removeChild(ol);
+  });
+  bar.classList.remove('collapsing');
 
   // Phase 1: collapse text
   bar.classList.add('collapsing');


### PR DESCRIPTION
## Summary
Orphaned oscilloscope canvases from interrupted turn transitions were left running. Now cleans up all existing .status-line canvases and cancels their animation frames at the start of each updateTurnIndicator call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)