### PR TITLE
feat: queue shot during AI turn

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -426,6 +426,18 @@ main {
   box-shadow: 0 0 8px #00ff8033, inset 0 0 6px #00ff8022;
 }
 
+.cell.queued {
+  border-color: #ffaa00;
+  background: #ffaa0018;
+  box-shadow: 0 0 6px #ffaa0033;
+  animation: queuedPulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes queuedPulse {
+  from { box-shadow: 0 0 4px #ffaa0022; }
+  to { box-shadow: 0 0 10px #ffaa0044; }
+}
+
 .cell.wave {
   animation: wave3d var(--wave-duration, 0.6s) ease-out forwards;
   animation-delay: var(--wave-delay, 0s);

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -12,6 +12,7 @@ var currentRoomId = null;
 var myTurn = false;
 var mySocketId = null;
 var enemySunkShips = [];
+var _queuedShot = null; // { row, col }
 
 // ---------------------------------------------------------------------------
 // SoundManager
@@ -263,9 +264,43 @@ function _spawnRipple(row, col) {
   }, cleanupTime);
 }
 
+function _clearQueuedShot() {
+  if (_queuedShot) {
+    var board = document.getElementById('board-enemy');
+    if (board) {
+      var cell = board.querySelector('.cell[data-row="' + _queuedShot.row + '"][data-col="' + _queuedShot.col + '"]');
+      if (cell) cell.classList.remove('queued');
+    }
+    _queuedShot = null;
+  }
+}
+
+function _setQueuedShot(row, col) {
+  _clearQueuedShot();
+  _queuedShot = { row: row, col: col };
+  var board = document.getElementById('board-enemy');
+  if (board) {
+    var cell = board.querySelector('.cell[data-row="' + row + '"][data-col="' + col + '"]');
+    if (cell) cell.classList.add('queued');
+  }
+}
+
 function fireAt(row, col) {
-  if (!myTurn) return;
   if (!socket) return;
+
+  if (!myTurn) {
+    // Queue the shot for when turn resumes
+    var board = document.getElementById('board-enemy');
+    if (board) {
+      var cell = board.querySelector('.cell[data-row="' + row + '"][data-col="' + col + '"]');
+      if (cell && !cell.classList.contains('hit') && !cell.classList.contains('miss') && !cell.classList.contains('sunk')) {
+        _setQueuedShot(row, col);
+      }
+    }
+    return;
+  }
+
+  _clearQueuedShot();
 
   // Disable enemy board clicks immediately
   myTurn = false;
@@ -567,6 +602,7 @@ function connectSocket() {
   // ---- game-start: both players ready, game begins --------------------------
   socket.on('game-start', function (data) {
     enemySunkShips = [];
+    _queuedShot = null;
     if (typeof showScreen === 'function') showScreen('screen-game');
     showDifficultyBadge();
     updateEnemySunkTracker();
@@ -673,6 +709,14 @@ function connectSocket() {
     }
 
     // status-message updated by updateTurnIndicator
+
+    // Fire queued shot if one exists
+    if (myTurn && _queuedShot) {
+      var qr = _queuedShot.row;
+      var qc = _queuedShot.col;
+      _clearQueuedShot();
+      setTimeout(function () { fireAt(qr, qc); }, 100);
+    }
   });
 
   // ---- game-over ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Click enemy cell during opponent's turn → queues the shot with amber pulse highlight
- When turn resumes, auto-fires after 100ms delay
- Latest click overwrites previous queue
- Only untargeted cells can be queued
- Queue cleared on game start

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)