### PR TITLE
feat: ripple on player board for opponent hits

### DIFF
--- a/public/js/game.js
+++ b/public/js/game.js
@@ -232,9 +232,9 @@ function _shakeScreen(style) {
  * Emits a 'fire' event if it is this player's turn.
  * Temporarily disables the enemy board to prevent double-fire.
  */
-function _spawnRipple(row, col) {
+function _spawnRipple(row, col, boardId) {
   if (typeof MotionSettings !== 'undefined' && !MotionSettings.enabled) return;
-  var board = document.getElementById('board-enemy');
+  var board = document.getElementById(boardId || 'board-enemy');
   if (!board) return;
 
   var cells = board.querySelectorAll('.cell');
@@ -692,6 +692,7 @@ function connectSocket() {
         SoundManager.play(data.sunk ? 'sunk' : 'hit');
         if (data.sunk) SoundManager.play('explosion');
         _shakeScreen(data.sunk ? 'defense-sunk' : 'defense-hit');
+        _spawnRipple(data.row, data.col, 'board-player');
       } else {
         SoundManager.play('miss');
       }


### PR DESCRIPTION
## Summary
- _spawnRipple parameterized to accept any board ID
- Opponent hits now trigger 3D water ripple on the player's small board
- Same wave physics as enemy board (distance-based delay + amplitude decay)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)