### PR TITLE
fix: cleaner crosshair icon glow

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -187,13 +187,13 @@ main {
   width: 1.2em;
   height: 1.2em;
   vertical-align: -0.15em;
-  filter: drop-shadow(0 0 6px #00ff80);
-  animation: crosshairPulse 3s ease-in-out infinite;
+  filter: drop-shadow(0 0 8px #00ff80);
+  animation: crosshairPulse 4s ease-in-out infinite;
 }
 
 @keyframes crosshairPulse {
-  0%, 100% { filter: drop-shadow(0 0 3px #00ff8044); transform: scale(1); }
-  50% { filter: drop-shadow(0 0 12px #00ff80) drop-shadow(0 0 25px #00ff8066); transform: scale(1.05); }
+  0%, 100% { filter: drop-shadow(0 0 6px #00ff8055); }
+  50% { filter: drop-shadow(0 0 10px #00ff80cc); }
 }
 
 /* ===== Screens ===== */


### PR DESCRIPTION
## Summary
- Single drop-shadow matching heading text-shadow spread
- Removed scale pulse (was 1.05x), now just opacity shift
- Slower 4s cycle for calmer feel
- Glow is cohesive with the title text

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)