### PR TITLE
fix: reduce CRT vignette for better edge readability

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -78,9 +78,9 @@ body::before {
   inset: 0;
   background: radial-gradient(
     ellipse at center,
-    transparent 50%,
-    rgba(0,0,0,0.5) 80%,
-    rgba(0,0,0,0.85) 100%
+    transparent 60%,
+    rgba(0,0,0,0.25) 85%,
+    rgba(0,0,0,0.45) 100%
   );
   pointer-events: none;
   z-index: 9998;


### PR DESCRIPTION
## Summary

Closes #156

Vignette was too aggressive (0.85 opacity at edges), making text near screen edges hard to read. Reduced to 0.45 with a wider transparent center.

## Test plan
- [x] All 91 tests pass
- [ ] Text readable at edges on mobile and desktop
- [ ] CRT atmosphere still present


🤖 Generated with [Claude Code](https://claude.com/claude-code)