### PR TITLE
fix: board layout between 600-716px

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -473,14 +473,12 @@ main {
 }
 
 .board-large {
-  width: 400px;
-  max-width: 100%;
+  width: min(400px, 100%);
   margin: 0 auto;
 }
 
 .board-small {
-  width: 280px;
-  max-width: 100%;
+  width: min(280px, 100%);
   margin: 0 auto;
 }
 
@@ -685,6 +683,7 @@ main {
   gap: 32px;
   align-items: flex-start;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .board-column {
@@ -693,11 +692,13 @@ main {
 }
 
 .board-column-primary {
-  flex: 0 0 auto;
+  flex: 1 1 400px;
+  min-width: 0;
 }
 
 .board-column-secondary {
-  flex: 0 0 auto;
+  flex: 0 1 280px;
+  min-width: 0;
 }
 
 .board-label {


### PR DESCRIPTION
## Summary

Closes #155

Boards overflow viewport between 600-716px because the mobile breakpoint ends at 600px but side-by-side boards need ~712px minimum. Fixed by making board columns flex-shrinkable.

## Test plan
- [x] All 91 tests pass
- [ ] Boards fit at 650px viewport width
- [ ] Desktop layout unchanged at >716px
- [ ] Mobile layout unchanged at <600px


🤖 Generated with [Claude Code](https://claude.com/claude-code)