### PR TITLE
feat: Google Analytics via env var injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ JWT_SECRET=change-me-to-a-random-string
 # ALLOWED_ORIGINS=https://yourdomain.com
 
 PORT=3000
+
+# Google Analytics measurement ID (optional — omit to disable tracking)
+# GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/server/index.js
+++ b/server/index.js
@@ -97,9 +97,18 @@ app.get('/changelog', (req, res) => {
 
 // ---------------------------------------------------------------------------
 // SPA fallback — must come after API routes
+// Injects Google Analytics tag if GA_MEASUREMENT_ID is set
 // ---------------------------------------------------------------------------
+const indexPath = path.join(__dirname, '..', 'public', 'index.html');
+let indexHtml = fs.readFileSync(indexPath, 'utf8');
+const gaId = process.env.GA_MEASUREMENT_ID;
+if (gaId) {
+  const gaSnippet = `<!-- Google Analytics -->\n<script async src="https://www.googletagmanager.com/gtag/js?id=${gaId}"></script>\n<script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${gaId}');</script>`;
+  indexHtml = indexHtml.replace('</head>', gaSnippet + '\n</head>');
+}
+
 app.get('/{*splat}', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+  res.type('html').send(indexHtml);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #153

Injects GA tag server-side into index.html when `GA_MEASUREMENT_ID` env var is set. No tracking IDs committed to the repo.

## Test plan
- [x] All 91 tests pass
- [ ] GA tag appears in page source when env var is set
- [ ] No GA tag when env var is omitted
- [ ] `.env.example` updated with commented placeholder


🤖 Generated with [Claude Code](https://claude.com/claude-code)