### PR TITLE
fix: GA tag missing on root URL

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -75,7 +75,7 @@ app.use(express.json({ limit: '10kb' }));
 // ---------------------------------------------------------------------------
 // Static files
 // ---------------------------------------------------------------------------
-app.use(express.static(path.join(__dirname, '..', 'public')));
+app.use(express.static(path.join(__dirname, '..', 'public'), { index: false }));
 
 // ---------------------------------------------------------------------------
 // API routes


### PR DESCRIPTION
express.static served index.html before the injection route. Fixed with `{ index: false }`.