### PR TITLE
feat: GA4 custom event tracking

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -234,6 +234,7 @@ var AuthUI = {
           localStorage.setItem('battleship_token', result.data.token);
           AuthUI.updateNav();
           AuthUI.hideModal();
+          if (typeof trackEvent === 'function') trackEvent('login');
           // Reconnect socket with new token
           if (typeof connectSocket === 'function' && typeof socket !== 'undefined') {
             if (socket) socket.disconnect();
@@ -265,6 +266,7 @@ var AuthUI = {
           localStorage.setItem('battleship_token', result.data.token);
           AuthUI.updateNav();
           AuthUI.hideModal();
+          if (typeof trackEvent === 'function') trackEvent('account_created');
           // Reconnect socket with new token
           if (typeof connectSocket === 'function' && typeof socket !== 'undefined') {
             if (socket) socket.disconnect();

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -5,11 +5,19 @@
 'use strict';
 
 // ---------------------------------------------------------------------------
+// Analytics helper — safe to call even when GA is not loaded
+// ---------------------------------------------------------------------------
+function trackEvent(name, params) {
+  if (typeof gtag === 'function') gtag('event', name, params || {});
+}
+
+// ---------------------------------------------------------------------------
 // Global state
 // ---------------------------------------------------------------------------
 var socket = null;
 var currentRoomId = null;
 var myTurn = false;
+var _gameStartTime = 0;
 var mySocketId = null;
 var enemySunkShips = [];
 var _queuedShot = null; // { row, col }
@@ -670,6 +678,7 @@ function connectSocket() {
 
   // ---- room-created: private PvP room created --------------------------------
   socket.on('room-created', function (data) {
+    trackEvent('multiplayer_room_created');
     currentRoomId = data.roomId;
     var display = document.getElementById('room-code-display');
     if (display) display.textContent = data.roomId;
@@ -678,6 +687,7 @@ function connectSocket() {
 
   // ---- player-joined: second player joined a private room -------------------
   socket.on('player-joined', function (data) {
+    trackEvent('multiplayer_room_joined');
     var count = data.playerCount;
     var waitingText = document.querySelector('#screen-room .waiting-text');
     if (waitingText) {
@@ -724,9 +734,12 @@ function connectSocket() {
   socket.on('game-start', function (data) {
     enemySunkShips = [];
     _queuedShot = null;
+    _gameStartTime = Date.now();
     if (typeof showScreen === 'function') showScreen('screen-game');
     showDifficultyBadge();
     updateEnemySunkTracker();
+    var mode = (typeof _lastGameMode !== 'undefined' && _lastGameMode) ? _lastGameMode : {};
+    trackEvent('game_start', { mode: mode.type || 'unknown', difficulty: mode.difficulty || '' });
     // Request full state after showing game screen
     if (socket) socket.emit('get-state');
   });
@@ -779,6 +792,7 @@ function connectSocket() {
 
     // Track and show sunk ships
     if (data.sunk && data.shipName) {
+      trackEvent('ship_sunk', { ship_name: data.shipName, is_player: !isMyShot });
       if (isMyShot) {
         enemySunkShips.push(data.shipName);
         updateEnemySunkTracker();
@@ -811,6 +825,15 @@ function connectSocket() {
   socket.on('game-over', function (data) {
     var iWon = (data.winner === socket.id);
     myTurn = false;
+    var mode = (typeof _lastGameMode !== 'undefined' && _lastGameMode) ? _lastGameMode : {};
+    var duration = _gameStartTime ? Math.round((Date.now() - _gameStartTime) / 1000) : 0;
+    trackEvent('game_end', {
+      result: iWon ? 'win' : 'loss',
+      mode: mode.type || 'unknown',
+      difficulty: mode.difficulty || '',
+      turns_taken: data.turns || 0,
+      duration_seconds: duration
+    });
 
     if (typeof showGameOver === 'function') {
       showGameOver({

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -839,6 +839,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var btnCreateRoom = document.getElementById('btn-create-room');
   if (btnCreateRoom) {
     btnCreateRoom.addEventListener('click', function () {
+      _lastGameMode = { type: 'multiplayer' };
       if (socket) socket.emit('create-room');
     });
   }
@@ -1094,6 +1095,7 @@ document.addEventListener('DOMContentLoaded', function () {
       document.documentElement.setAttribute('data-theme', theme);
       swatches.forEach(function (s) { s.classList.remove('active'); });
       swatch.classList.add('active');
+      trackEvent('theme_changed', { theme_name: theme });
     });
   });
 
@@ -1101,6 +1103,7 @@ document.addEventListener('DOMContentLoaded', function () {
   var btnPlayAgain = document.getElementById('btn-play-again');
   if (btnPlayAgain) {
     btnPlayAgain.addEventListener('click', function () {
+      trackEvent('play_again');
       if (_lastGameMode && _lastGameMode.type === 'ai' && socket) {
         socket.emit('create-ai-game', { difficulty: _lastGameMode.difficulty });
       } else {
@@ -1172,6 +1175,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (placementState.placedShips.length < FLEET.length) return;
     if (socket) {
       socket.emit('place-ships', { ships: placementState.placedShips });
+      trackEvent('placement_complete');
     }
   }
   if (btnReady) {


### PR DESCRIPTION
## Summary

Closes #178

Adds custom GA4 events at key engagement points. All calls go through a `trackEvent()` helper that guards against missing `gtag`.

## Events
- game_start, game_end, ship_sunk, play_again
- placement_complete, theme_changed
- multiplayer_room_created, multiplayer_room_joined
- login, account_created

## Test plan
- [x] All 91 tests pass
- [ ] Events visible in GA4 Realtime → Events


🤖 Generated with [Claude Code](https://claude.com/claude-code)