### PR TITLE
fix: safe area inset for home bar, disable zoom

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1648,7 +1648,7 @@ main {
     flex-direction: column;
     align-items: center;
     gap: 20px;
-    padding-bottom: calc(25vw + 50px);
+    padding-bottom: calc(25vw + 50px + env(safe-area-inset-bottom, 0px));
   }
 
   .board-large {

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <title>Cyber Ship Battle — Free Online Naval Strategy Game</title>
   <meta name="description" content="Play Cyber Ship Battle online for free — challenge the AI at 3 difficulty levels or battle friends in real-time multiplayer. No download, no signup required.">
   <meta name="robots" content="index, follow">


### PR DESCRIPTION
## Summary

Closes #170

- `viewport-fit=cover` enables `env(safe-area-inset-bottom)` on iPhones (was returning 0 without it)
- `maximum-scale=1, user-scalable=no` prevents pinch zoom
- Game layout padding accounts for safe area

## Test plan
- [x] All 91 tests pass
- [ ] Thumbnail panel clears home bar on iPhone
- [ ] Pinch zoom disabled
- [ ] No scrolling on game screen


🤖 Generated with [Claude Code](https://claude.com/claude-code)