### PR TITLE
fix: mobile game board fills available width

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1646,17 +1646,17 @@ main {
 
   .game-layout {
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 20px;
     padding-bottom: calc(25vw + 50px + env(safe-area-inset-bottom, 0px));
   }
 
-  .board-large {
-    max-width: 100%;
+  .board-column-primary {
+    width: 100%;
   }
 
-  .board-small {
-    max-width: 100%;
+  .board-large {
+    width: 100%;
   }
 
   .placement-container,


### PR DESCRIPTION
## Summary

Closes #182

Board was shrink-wrapped by `align-items: center` on the flex column layout. Changed to `stretch` and set board to `width: 100%` on mobile.

## Test plan
- [x] All 91 tests pass
- [ ] Board fills width on mobile
- [ ] Cells tappable
- [ ] Desktop unchanged


🤖 Generated with [Claude Code](https://claude.com/claude-code)