### PR TITLE
fix: miss marker contrast

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -569,8 +569,8 @@ main {
 }
 
 .cell.miss {
-  background: #ffffff11;
-  border-color: #ffffff22;
+  background: #ffffff18;
+  border-color: #ffffff44;
 }
 
 .cell.ship {


### PR DESCRIPTION
Closes #168. Bumped miss cell opacity so they're visible on mobile without being distracting.