### PR TITLE
fix: Fleet Ready notification overlap on mobile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1895,6 +1895,10 @@ main {
     z-index: 9999;
   }
 
+  .notification {
+    z-index: 10000;
+  }
+
   .nav-hamburger {
     display: block;
   }


### PR DESCRIPTION
## Summary
- Raises `.notification` z-index to `10000` on mobile so it renders above the nav bar (`z-index: 9999`) instead of partially behind it
- Matches desktop behavior where the notification already floats above the nav

Closes #188

## Test plan
- [ ] Open placement screen on mobile (375px width)
- [ ] Place all ships or click Randomize to trigger "FLEET READY" notification
- [ ] Verify notification appears cleanly above nav, no overlap with heading or hint text
- [ ] Verify desktop notification is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)